### PR TITLE
Update pwa interface

### DIFF
--- a/example-app/src/main/java/com/getdreams/example/MainActivity.kt
+++ b/example-app/src/main/java/com/getdreams/example/MainActivity.kt
@@ -8,25 +8,21 @@ package com.getdreams.example
 
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.util.Log
 import com.getdreams.connections.EventListener
 import com.getdreams.events.Event
-import com.getdreams.events.ResponseType
 import com.getdreams.views.DreamsView
 
 class MainActivity : AppCompatActivity() {
     private val dreamsView: DreamsView by lazy { findViewById(R.id.dreams) }
 
-    private val listener = EventListener { event, _ ->
+    private val listener = EventListener { event ->
         when (event) {
-            is Event.Response -> {
-                when (event.type) {
-                    ResponseType.AccessTokenExpired -> {
-                        dreamsView.updateAccessToken("new_token")
-                    }
-                    ResponseType.OffboardingCompleted -> {
-                        this@MainActivity.finish()
-                    }
-                }
+            is Event.IdTokenExpired -> {
+                dreamsView.updateIdToken("new_token")
+            }
+            is Event.Telemetry -> {
+                Log.v("MainActivity", "Got telemetry ${event.name}: ${event.payload?.toString(2)}")
             }
         }
     }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -31,10 +31,6 @@ android {
             includeAndroidResources = true
         }
     }
-
-    useLibrary 'android.test.runner'
-    useLibrary 'android.test.base'
-    useLibrary 'android.test.mock'
 }
 
 dependencies {

--- a/sdk/src/androidTest/java/com/getdreams/views/DreamsViewTest.kt
+++ b/sdk/src/androidTest/java/com/getdreams/views/DreamsViewTest.kt
@@ -50,10 +50,10 @@ class DreamsViewTest {
     }
 
     @Test
-    fun updateAccessToken() {
+    fun updateIdToken() {
         activityRule.scenario.onActivity {
             val dreamsView = DreamsView(it)
-            dreamsView.updateAccessToken("new_token")
+            dreamsView.updateIdToken("new_token")
         }
     }
 

--- a/sdk/src/main/java/com/getdreams/connections/EventListener.kt
+++ b/sdk/src/main/java/com/getdreams/connections/EventListener.kt
@@ -7,17 +7,15 @@
 package com.getdreams.connections
 
 import com.getdreams.events.Event
-import org.json.JSONObject
 
 /**
- * Listener for response events from Dreams.
+ * Listener for events from Dreams.
  */
 fun interface EventListener {
     /**
      * Triggered when a [Event] is sent from PWA.
      *
-     * @param type The type of response.
-     * @param data The data of the response.
+     * @param event The event that was sent.
      */
-    fun onEvent(type: Event, data: JSONObject?)
+    fun onEvent(event: Event)
 }

--- a/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
+++ b/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
@@ -1,0 +1,33 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.getdreams.connections.webview
+
+import com.getdreams.Location
+import java.util.Locale
+
+/**
+ * Interface for requests to the Dreams PWA.
+ */
+interface RequestInterface {
+    /**
+     * Open Dreams at [location].
+     *
+     * @param idToken The token used to authenticate.
+     * @param location What screen to open, by default `home`.
+     */
+    fun open(idToken: String, location: String = Location.Home.value, locale: Locale? = null)
+
+    /**
+     * Set the locale used in Dreams.
+     */
+    fun updateLocale(locale: Locale)
+
+    /**
+     * Update the id token.
+     */
+    fun updateIdToken(idToken: String)
+}

--- a/sdk/src/main/java/com/getdreams/connections/webview/ResponseInterface.kt
+++ b/sdk/src/main/java/com/getdreams/connections/webview/ResponseInterface.kt
@@ -7,17 +7,18 @@
 package com.getdreams.connections.webview
 
 /**
- * Interface for communication from the Dreams PWA.
+ * Interface for responses from the Dreams PWA.
  */
 internal interface ResponseInterface {
+    /**
+     * The token expired.
+     */
+    fun onIdTokenDidExpire()
 
     /**
-     * Access token expired.
+     * A telemetry event was sent.
+     *
+     * @param data A JSON-string with the telemetry data.
      */
-    fun onAccessTokenDidExpire()
-
-    /**
-     * User offboarded.
-     */
-    fun onOffboardingDidComplete()
+    fun onTelemetryEvent(data: String)
 }

--- a/sdk/src/main/java/com/getdreams/events/Event.kt
+++ b/sdk/src/main/java/com/getdreams/events/Event.kt
@@ -6,19 +6,19 @@
 
 package com.getdreams.events
 
-@Suppress("unused")
-enum class RequestType {
-    UpdateAccessToken,
-    UpdateLocale,
-}
-
-@Suppress("unused")
-enum class ResponseType {
-    AccessTokenExpired,
-    OffboardingCompleted,
-}
+import org.json.JSONObject
 
 sealed class Event {
-    data class Request(val type: RequestType): Event()
-    data class Response(val type: ResponseType): Event()
+    /**
+     * Event sent when token has expired.
+     */
+    object IdTokenExpired : Event()
+
+    /**
+     * Telemetry event.
+     *
+     * @param name The name of the telemetry.
+     * @param payload The optional payload.
+     */
+    data class Telemetry(val name: String, val payload: JSONObject?) : Event()
 }

--- a/sdk/src/main/java/com/getdreams/views/DreamsViewInterface.kt
+++ b/sdk/src/main/java/com/getdreams/views/DreamsViewInterface.kt
@@ -8,29 +8,22 @@ package com.getdreams.views
 
 import com.getdreams.Location
 import com.getdreams.connections.EventListener
+import com.getdreams.connections.webview.RequestInterface
 import java.util.Locale
 
 /**
  * Interface for [DreamsView].
  */
-interface DreamsViewInterface {
+interface DreamsViewInterface : RequestInterface {
     /**
      * Open Dreams at [location].
      *
-     * @param accessToken The token used to authenticate.
-     * @param location What screen to open, by default [Location.Home].
+     * @param idToken The token used to authenticate.
+     * @param location What screen to open.
      */
-    fun open(accessToken: String, location: Location = Location.Home, locale: Locale? = null)
-
-    /**
-     * Set the locale used in Dreams.
-     */
-    fun updateLocale(locale: Locale)
-
-    /**
-     * Update the access token.
-     */
-    fun updateAccessToken(accessToken: String)
+    fun open(idToken: String, location: Location, locale: Locale? = null) {
+        open(idToken, location.value, locale)
+    }
 
     /**
      * Listen to events from Dreams.

--- a/sdk/src/test/java/com/getdreams/views/DreamsViewUnitTest.kt
+++ b/sdk/src/test/java/com/getdreams/views/DreamsViewUnitTest.kt
@@ -12,6 +12,8 @@ import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.MediumTest
 import com.getdreams.Dreams
 import com.getdreams.connections.EventListener
+import com.getdreams.events.Event
+import org.json.JSONObject
 import org.junit.Test
 import org.junit.Assert.*
 import org.junit.Before
@@ -30,14 +32,14 @@ class DreamsViewUnitTest {
     @Test
     fun canRegisterResponseListener() {
         val dreamsView = DreamsView(context)
-        val listener = EventListener { _, _ -> TODO("Not yet implemented") }
+        val listener = EventListener { TODO("Not yet implemented") }
         assertTrue(dreamsView.registerEventListener(listener))
     }
 
     @Test
     fun canRemoveResponseListener() {
         val dreamsView = DreamsView(context)
-        val listener = EventListener { _, _ -> TODO("Not yet implemented") }
+        val listener = EventListener { TODO("Not yet implemented") }
         dreamsView.registerEventListener(listener)
         assertTrue(dreamsView.removeEventListener(listener))
     }
@@ -45,12 +47,21 @@ class DreamsViewUnitTest {
     @Test
     fun canClearResponseListeners() {
         val dreamsView = DreamsView(context)
-        val listener = EventListener { _, _ -> TODO("Not yet implemented") }
-        val listener2 = EventListener { _, _ -> TODO("Not yet implemented") }
+        val listener = EventListener { TODO("Not yet implemented") }
+        val listener2 = EventListener { TODO("Not yet implemented") }
         dreamsView.registerEventListener(listener)
         dreamsView.registerEventListener(listener2)
         dreamsView.clearEventListeners()
         assertFalse(dreamsView.removeEventListener(listener))
         assertFalse(dreamsView.removeEventListener(listener2))
+    }
+
+    @Test
+    fun responseEventIsSentToListener() {
+        val event = Event.Telemetry("name", JSONObject("""{"param_1":true}"""))
+        val dreamsView = DreamsView(context)
+        val listener = EventListener { assertEquals(event, it) }
+        dreamsView.registerEventListener(listener)
+        dreamsView.onResponse(event)
     }
 }


### PR DESCRIPTION
A couple of change, first is a simple rename of access token to id token.

The other change is to the events sent to sdk client, instead of sending a event with type and data
we send different event classes that can contain any data.
