### PR TITLE
Refactor how tokens are sent to the SDK

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ class ExampleApp : Application() {
 }
 ```
 
-To show Dreams simply add `DreamsView` to a layout, and then call `DreamsView.open()`.
+To show Dreams simply add `DreamsView` to a layout, and then call `DreamsView.launch()`.
 
 ```xml
 <com.getdreams.views.DreamsView
@@ -83,7 +83,7 @@ To show Dreams simply add `DreamsView` to a layout, and then call `DreamsView.op
 
 ```kotlin
 val dreamsView: DreamsView = findViewById<DreamsView>(R.id.dreams)
-dreamsView.open(Dreams.Credentials(idToken = "user token"), location = Location.Home, locale = null)
+dreamsView.launch(Dreams.Credentials(idToken = "user token"))
 ```
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ To show Dreams simply add `DreamsView` to a layout, and then call `DreamsView.op
 
 ```kotlin
 val dreamsView: DreamsView = findViewById<DreamsView>(R.id.dreams)
-dreamsView.open(accessToken = "user token", location = Location.Home, locale = null)
+dreamsView.open(Dreams.Credentials(idToken = "user token"), location = Location.Home, locale = null)
 ```
 
 ### Events

--- a/README.md
+++ b/README.md
@@ -100,15 +100,15 @@ dreamsView.registerEventListener { event ->
 
 #### Token renewal
 
-When a token requires renewal a `IdTokenExpired` event will be sent, to set a new token you need to call
- `DreamsView.updateIdToken` with the request id from the event and the new token.
+When a token requires renewal a `CredentialsExpired` event will be sent, to set a new token you need to call
+ `DreamsView.updateCredentials` with the request id from the event and the new token.
 
  ```kotlin
 dreamsView.registerEventListener { event ->
     when (event) {
-        is Event.IdTokenExpired -> {
+        is Event.CredentialsExpired -> {
             val newToken = getValidToken()
-            dreamsView.updateIdToken(requestId = event.requestId, idToken = newToken)
+            dreamsView.updateCredentials(requestId = event.requestId, credentials = Credentials(idToken = newToken))
         }
     }
 }

--- a/example-app/src/main/java/com/getdreams/example/MainActivity.kt
+++ b/example-app/src/main/java/com/getdreams/example/MainActivity.kt
@@ -9,6 +9,7 @@ package com.getdreams.example
 import android.os.Bundle
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
+import com.getdreams.Credentials
 import com.getdreams.connections.EventListener
 import com.getdreams.events.Event
 import com.getdreams.views.DreamsView
@@ -67,7 +68,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        dreamsView.open("token")
+        dreamsView.open(Credentials("token"))
         dreamsView.registerEventListener(listener)
     }
 

--- a/example-app/src/main/java/com/getdreams/example/MainActivity.kt
+++ b/example-app/src/main/java/com/getdreams/example/MainActivity.kt
@@ -68,7 +68,7 @@ class MainActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
-        dreamsView.open(Credentials("token"))
+        dreamsView.launch(Credentials("token"))
         dreamsView.registerEventListener(listener)
     }
 

--- a/example-app/src/main/java/com/getdreams/example/MainActivity.kt
+++ b/example-app/src/main/java/com/getdreams/example/MainActivity.kt
@@ -27,11 +27,11 @@ class MainActivity : AppCompatActivity() {
      */
     private val listener = EventListener { event ->
         when (event) {
-            is Event.IdTokenExpired -> {
+            is Event.CredentialsExpired -> {
                 // Renew the token
                 GlobalScope.launch {
-                    val newToken = FakeBackend.refreshIdToken()
-                    dreamsView.updateIdToken(requestId = event.requestId, idToken = newToken)
+                    val credentials = Credentials(idToken = FakeBackend.refreshIdToken())
+                    dreamsView.updateCredentials(requestId = event.requestId, credentials)
                 }
             }
             is Event.Telemetry -> {

--- a/example-app/src/main/java/com/getdreams/example/MainActivity.kt
+++ b/example-app/src/main/java/com/getdreams/example/MainActivity.kt
@@ -48,13 +48,13 @@ class MainActivity : AppCompatActivity() {
                         dreamsView.accountProvisionInitiated(requestId = event.requestId)
                     } else {
                         // Something went wrong with provisioning the account
-                            GlobalScope.launch(Dispatchers.Main) {
-                                Toast.makeText(
-                                    this@MainActivity,
-                                    "Could not provision account",
-                                    Toast.LENGTH_SHORT
-                                ).show()
-                            }
+                        GlobalScope.launch(Dispatchers.Main) {
+                            Toast.makeText(
+                                this@MainActivity,
+                                "Could not provision account",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        }
                     }
                 }
             }

--- a/sdk/src/androidTest/assets/index.html
+++ b/sdk/src/androidTest/assets/index.html
@@ -26,7 +26,7 @@
         console.assert(obj.hasOwnProperty('requestId'), 'missing request id');
         return obj.hasOwnProperty('idToken') && obj.hasOwnProperty('requestId');
     }
-    function accountProvisioned() {
+    function accountProvisionInitiated() {
         return "OK";
     }
     function onEvent(name, location) {

--- a/sdk/src/androidTest/java/com/getdreams/test/utils/TestUtils.kt
+++ b/sdk/src/androidTest/java/com/getdreams/test/utils/TestUtils.kt
@@ -13,6 +13,7 @@ import androidx.test.espresso.web.webdriver.DriverAtoms.webClick
 import androidx.test.espresso.web.webdriver.Locator
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.platform.app.InstrumentationRegistry
+import com.getdreams.Credentials
 import com.getdreams.R
 import com.getdreams.TestActivity
 import com.getdreams.events.Event
@@ -45,7 +46,7 @@ inline fun ActivityScenarioRule<TestActivity>.testResponseEvent(
     val contentLatch = CountDownLatch(1)
     scenario.onActivity { activity ->
         val dreamsView = activity.findViewById<DreamsView>(R.id.dreams)
-        dreamsView.open("token")
+        dreamsView.open(Credentials("token"))
         dreamsView.registerEventListener { event ->
             when (event) {
                 is Event.Telemetry -> {

--- a/sdk/src/androidTest/java/com/getdreams/test/utils/TestUtils.kt
+++ b/sdk/src/androidTest/java/com/getdreams/test/utils/TestUtils.kt
@@ -46,7 +46,7 @@ inline fun ActivityScenarioRule<TestActivity>.testResponseEvent(
     val contentLatch = CountDownLatch(1)
     scenario.onActivity { activity ->
         val dreamsView = activity.findViewById<DreamsView>(R.id.dreams)
-        dreamsView.open(Credentials("token"))
+        dreamsView.launch(Credentials("token"))
         dreamsView.registerEventListener { event ->
             when (event) {
                 is Event.Telemetry -> {

--- a/sdk/src/androidTest/java/com/getdreams/views/DreamsViewTest.kt
+++ b/sdk/src/androidTest/java/com/getdreams/views/DreamsViewTest.kt
@@ -136,8 +136,8 @@ class DreamsViewTest {
     fun updateIdToken() {
         val latch = CountDownLatch(1)
         activityRule.testResponseEvent("expire_token_button") { event, view ->
-            assertEquals(Event.IdTokenExpired("uuid"), event)
-            view.updateIdToken((event as Event.IdTokenExpired).requestId, "new token")
+            assertEquals(Event.CredentialsExpired("uuid"), event)
+            view.updateCredentials((event as Event.CredentialsExpired).requestId, Credentials("new token"))
             GlobalScope.launch {
                 delay(250)
                 latch.countDown()

--- a/sdk/src/androidTest/java/com/getdreams/views/DreamsViewTest.kt
+++ b/sdk/src/androidTest/java/com/getdreams/views/DreamsViewTest.kt
@@ -9,6 +9,7 @@ package com.getdreams.views
 import androidx.test.ext.junit.rules.ActivityScenarioRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.filters.LargeTest
+import com.getdreams.Credentials
 import com.getdreams.Dreams
 import com.getdreams.R
 import com.getdreams.TestActivity
@@ -71,12 +72,10 @@ class DreamsViewTest {
 
     @Test
     fun open() {
-        server.dispatcher = MockDreamsDispatcher(server)
-
         val latch = CountDownLatch(1)
         activityRule.scenario.onActivity {
             val dreamsView = it.findViewById<DreamsView>(R.id.dreams)
-            dreamsView.open("id token", locale = Locale.CANADA_FRENCH)
+            dreamsView.open(Credentials("id token"), locale = Locale.CANADA_FRENCH)
             dreamsView.registerEventListener { event ->
                 when (event) {
                     is Event.Telemetry -> {
@@ -109,7 +108,7 @@ class DreamsViewTest {
         val latch = CountDownLatch(1)
         activityRule.scenario.onActivity {
             val dreamsView = it.findViewById<DreamsView>(R.id.dreams)
-            dreamsView.open("token")
+            dreamsView.open(Credentials("token"))
             dreamsView.registerEventListener { event ->
                 when (event) {
                     is Event.Telemetry -> {

--- a/sdk/src/androidTest/java/com/getdreams/views/DreamsViewTest.kt
+++ b/sdk/src/androidTest/java/com/getdreams/views/DreamsViewTest.kt
@@ -75,7 +75,7 @@ class DreamsViewTest {
         val latch = CountDownLatch(1)
         activityRule.scenario.onActivity {
             val dreamsView = it.findViewById<DreamsView>(R.id.dreams)
-            dreamsView.open(Credentials("id token"), locale = Locale.CANADA_FRENCH)
+            dreamsView.launch(Credentials("id token"), locale = Locale.CANADA_FRENCH)
             dreamsView.registerEventListener { event ->
                 when (event) {
                     is Event.Telemetry -> {
@@ -108,7 +108,7 @@ class DreamsViewTest {
         val latch = CountDownLatch(1)
         activityRule.scenario.onActivity {
             val dreamsView = it.findViewById<DreamsView>(R.id.dreams)
-            dreamsView.open(Credentials("token"))
+            dreamsView.launch(Credentials("token"))
             dreamsView.registerEventListener { event ->
                 when (event) {
                     is Event.Telemetry -> {

--- a/sdk/src/main/java/com/getdreams/Credentials.kt
+++ b/sdk/src/main/java/com/getdreams/Credentials.kt
@@ -1,0 +1,14 @@
+/*
+ * This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
+ */
+
+package com.getdreams
+
+/**
+ * Class containing the user's credentials.
+ *
+ * @param idToken The token used to authenticate the user.
+ */
+data class Credentials(val idToken: String)

--- a/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
+++ b/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
@@ -7,6 +7,7 @@
 package com.getdreams.connections.webview
 
 import com.getdreams.Location
+import com.getdreams.Credentials
 import java.util.Locale
 
 /**
@@ -16,10 +17,10 @@ interface RequestInterface {
     /**
      * Open Dreams at [location].
      *
-     * @param idToken The token used to authenticate.
+     * @param credentials Credentials used to authenticate the user.
      * @param location What screen to open, by default `home`.
      */
-    fun open(idToken: String, location: String = Location.Home.value, locale: Locale? = null)
+    fun open(credentials: Credentials, location: String = Location.Home.value, locale: Locale? = null)
 
     /**
      * Set the locale used in Dreams.

--- a/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
+++ b/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
@@ -33,9 +33,9 @@ interface RequestInterface {
      * Update the id token.
      *
      * @param requestId The request id of the event that informed that the token was expired.
-     * @param idToken The new id token.
+     * @param credentials The new credentials to use.
      */
-    fun updateIdToken(requestId: String, idToken: String)
+    fun updateCredentials(requestId: String, credentials: Credentials)
 
     /**
      * Inform the web app that an account was provisioned.

--- a/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
+++ b/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
@@ -15,12 +15,13 @@ import java.util.Locale
  */
 interface RequestInterface {
     /**
-     * Open Dreams at [location].
+     * Launch Dreams at [location].
      *
      * @param credentials Credentials used to authenticate the user.
      * @param location What screen to open, by default `home`.
+     * @param locale If set overrides the user locale.
      */
-    fun open(credentials: Credentials, location: String = Location.Home.value, locale: Locale? = null)
+    fun launch(credentials: Credentials, location: String = Location.Home.value, locale: Locale? = null)
 
     /**
      * Set the locale used in Dreams.

--- a/sdk/src/main/java/com/getdreams/events/Event.kt
+++ b/sdk/src/main/java/com/getdreams/events/Event.kt
@@ -10,9 +10,9 @@ import org.json.JSONObject
 
 sealed class Event {
     /**
-     * Event sent when token has expired.
+     * Event sent when the user credentials has expired.
      */
-    data class IdTokenExpired(override val requestId: String) : RequestData, Event()
+    data class CredentialsExpired(override val requestId: String) : RequestData, Event()
 
     /**
      * Telemetry event.

--- a/sdk/src/main/java/com/getdreams/views/DreamsView.kt
+++ b/sdk/src/main/java/com/getdreams/views/DreamsView.kt
@@ -31,6 +31,7 @@ import java.net.URL
 import java.util.Locale
 import java.util.concurrent.CopyOnWriteArrayList
 import com.getdreams.Result
+import com.getdreams.Credentials
 import com.getdreams.events.Event
 import org.json.JSONException
 import org.json.JSONTokener
@@ -235,7 +236,7 @@ class DreamsView : FrameLayout, DreamsViewInterface {
         }
     }
 
-    override fun open(idToken: String, location: String, locale: Locale?) {
+    override fun open(credentials: Credentials, location: String, locale: Locale?) {
         val posixLocale = locale?.posix ?: with(resources.configuration) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 locales[0] ?: Locale.ROOT
@@ -246,7 +247,7 @@ class DreamsView : FrameLayout, DreamsViewInterface {
         }.posix
 
         GlobalScope.launch {
-            val url = getUrl(Dreams.instance.clientId, idToken, posixLocale)
+            val url = getUrl(Dreams.instance.clientId, credentials.idToken, posixLocale)
             withContext(Dispatchers.Main) {
                 if (url != null) {
                     webView.loadUrl(url)

--- a/sdk/src/main/java/com/getdreams/views/DreamsView.kt
+++ b/sdk/src/main/java/com/getdreams/views/DreamsView.kt
@@ -236,7 +236,7 @@ class DreamsView : FrameLayout, DreamsViewInterface {
         }
     }
 
-    override fun open(credentials: Credentials, location: String, locale: Locale?) {
+    override fun launch(credentials: Credentials, location: String, locale: Locale?) {
         val posixLocale = locale?.posix ?: with(resources.configuration) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
                 locales[0] ?: Locale.ROOT

--- a/sdk/src/main/java/com/getdreams/views/DreamsView.kt
+++ b/sdk/src/main/java/com/getdreams/views/DreamsView.kt
@@ -105,7 +105,7 @@ class DreamsView : FrameLayout, DreamsViewInterface {
                     val json = JSONTokener(requestData).nextValue() as? JSONObject?
                     val requestId = json?.getString("requestId")
                     if (requestId != null) {
-                        this@DreamsView.onResponse(Event.IdTokenExpired(requestId))
+                        this@DreamsView.onResponse(Event.CredentialsExpired(requestId))
                     }
                 } catch (e: JSONException) {
                     Log.w("Dreams", "Unable to parse request data", e)
@@ -266,10 +266,10 @@ class DreamsView : FrameLayout, DreamsViewInterface {
         }
     }
 
-    override fun updateIdToken(requestId: String, idToken: String) {
+    override fun updateCredentials(requestId: String, credentials: Credentials) {
         val jsonData: JSONObject = JSONObject()
             .put("requestId", requestId)
-            .put("idToken", idToken)
+            .put("idToken", credentials.idToken)
         GlobalScope.launch(Dispatchers.Main.immediate) {
             webView.evaluateJavascript("updateIdToken('${jsonData}')") {
                 Log.v("Dreams", "updateIdToken returned $it")

--- a/sdk/src/main/java/com/getdreams/views/DreamsViewInterface.kt
+++ b/sdk/src/main/java/com/getdreams/views/DreamsViewInterface.kt
@@ -21,9 +21,10 @@ interface DreamsViewInterface : RequestInterface {
      *
      * @param credentials Credentials used to authenticate the user.
      * @param location What screen to open.
+     * @param locale If set overrides the user locale.
      */
-    fun open(credentials: Credentials, location: Location, locale: Locale? = null) {
-        open(credentials, location.value, locale)
+    fun launch(credentials: Credentials, location: Location, locale: Locale? = null) {
+        launch(credentials, location.value, locale)
     }
 
     /**

--- a/sdk/src/main/java/com/getdreams/views/DreamsViewInterface.kt
+++ b/sdk/src/main/java/com/getdreams/views/DreamsViewInterface.kt
@@ -6,6 +6,7 @@
 
 package com.getdreams.views
 
+import com.getdreams.Credentials
 import com.getdreams.Location
 import com.getdreams.connections.EventListener
 import com.getdreams.connections.webview.RequestInterface
@@ -18,11 +19,11 @@ interface DreamsViewInterface : RequestInterface {
     /**
      * Open Dreams at [location].
      *
-     * @param idToken The token used to authenticate.
+     * @param credentials Credentials used to authenticate the user.
      * @param location What screen to open.
      */
-    fun open(idToken: String, location: Location, locale: Locale? = null) {
-        open(idToken, location.value, locale)
+    fun open(credentials: Credentials, location: Location, locale: Locale? = null) {
+        open(credentials, location.value, locale)
     }
 
     /**


### PR DESCRIPTION
Change from sending raw tokens to sending credential objects instead.
Also renamed `RequestInterface.open` to `RequestInterface.launch` to match the ios SDK.