### PR TITLE
Prepare release 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this library will be documented here.
 
+### [0.4.2](https://github.com/getdreams/dreams-android-sdk/compare/0.4.1...0.4.2) (2021-03-16)
+
+
+### Bug Fixes
+
+* always have the dreams web view intercept requests ([6b70d98](https://github.com/getdreams/dreams-android-sdk/commit/6b70d98fdf165166d94a2e8cc9bb01bad729c24a))
+
 ### [0.4.1](https://github.com/getdreams/dreams-android-sdk/compare/0.4.0...0.4.1) (2021-02-25)
 
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add the library to your module dependencies.
 
 ```groovy
 dependencies {
-    implementation 'com.getdreams:android-sdk:0.4.1'
+    implementation 'com.getdreams:android-sdk:0.4.2'
 }
 ```
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        versionName '0.4.1'
+        versionName '0.4.2'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"


### PR DESCRIPTION
### [0.4.2](https://github.com/getdreams/dreams-android-sdk/compare/0.4.1...0.4.2) (2021-03-16)

### Bug Fixes

* always have the dreams web view intercept requests ([6b70d98](https://github.com/getdreams/dreams-android-sdk/commit/6b70d98fdf165166d94a2e8cc9bb01bad729c24a))
