### PR TITLE
Add headers support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Add the library to your module dependencies.
 
 ```groovy
 dependencies {
-    implementation 'com.getdreams:android-sdk:0.6.0'
+    implementation 'com.getdreams:android-sdk:0.7.0'
 }
 ```
 

--- a/example-app/src/main/java/com/getdreams/example/ExampleApp.kt
+++ b/example-app/src/main/java/com/getdreams/example/ExampleApp.kt
@@ -13,6 +13,6 @@ import com.getdreams.Dreams
 class ExampleApp : Application() {
     override fun onCreate() {
         super.onCreate()
-        Dreams.configure(Dreams.Configuration(clientId = "clientId", baseUrl = "https://getdreams.io"))
+        Dreams.configure(Dreams.Configuration(clientId = "clientId", baseUrl = "https://sales.dreams-demo.io"))
     }
 }

--- a/example-app/src/main/java/com/getdreams/example/MainActivity.kt
+++ b/example-app/src/main/java/com/getdreams/example/MainActivity.kt
@@ -109,9 +109,18 @@ class MainActivity : AppCompatActivity() {
 
         val location = intent?.data?.path
         if (location.isNullOrBlank()) {
-            dreamsView.launch(Credentials("token"), Locale.ENGLISH, onLaunch)
+            dreamsView.launch(
+                credentials = Credentials("token"),
+                locale = Locale.ENGLISH,
+                onCompletion = onLaunch
+            )
         } else {
-            dreamsView.launch(Credentials("token"), Locale.ENGLISH, location, onLaunch)
+            dreamsView.launch(
+                credentials = Credentials("token"),
+                locale = Locale.ENGLISH,
+                location = location,
+                onCompletion = onLaunch
+            )
         }
 
         dreamsView.registerEventListener(listener)

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -72,7 +72,7 @@ tasks.findAll { it.name.contains("dokka") }.forEach {
                 includes.from("module.md")
                 sourceLink {
                     localDirectory.set(file("src/main/java"))
-                    remoteUrl.set(URL("https://github.com/getdreams/dreams-android-sdk/tree/master/sdk/"))
+                    remoteUrl.set(URL("https://github.com/dreamstechnology/dreams-android-sdk/tree/master/sdk/"))
                     remoteLineSuffix.set("#L")
                 }
                 includeNonPublic.set(false)
@@ -102,7 +102,7 @@ afterEvaluate {
         repositories {
             maven {
                 name = "GitHubPackages"
-                url = uri("https://maven.pkg.github.com/getdreams/dreams-android-sdk")
+                url = uri("https://maven.pkg.github.com/dreamstechnology/dreams-android-sdk")
                 credentials {
                     username = project.findProperty("gpr.user") ?: System.getenv("GITHUB_USERNAME")
                     password = project.findProperty("gpr.key") ?: System.getenv("GITHUB_TOKEN")
@@ -124,7 +124,7 @@ afterEvaluate {
                 pom {
                     name = 'Dreams Android SDK'
                     description = ''
-                    url = 'https://getdreams.com/'
+                    url = 'https://dreamstechnology.com/'
 
                     licenses {
                         license {
@@ -135,7 +135,7 @@ afterEvaluate {
                     scm {
                         connection = 'scm:git:git://github.com/dreams-android-sdk.git'
                         developerConnection = 'scm:git:ssh://github.com/dreams-android-sdk.git'
-                        url = 'https://getdreams.com/'
+                        url = 'https://dreamstechnology.com/'
                     }
                 }
 

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,7 +12,7 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        versionName '0.7.0'
+        versionName '0.8.0-rc.2'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
@@ -139,12 +139,12 @@ afterEvaluate {
                         url = 'https://dreamstechnology.com/'
                     }
                 }
-
-                signing {
-                    useGpgCmd()
-                    sign publishing.publications.release
-                }
             }
         }
+    }
+
+    signing {
+        useGpgCmd()
+        sign publishing.publications.release
     }
 }

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -12,11 +12,12 @@ android {
     defaultConfig {
         minSdkVersion 21
         targetSdkVersion 30
-        versionName '0.6.0'
+        versionName '0.7.0'
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
     }
+
 
     buildTypes {
         release {

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -47,6 +47,7 @@ dependencies {
     implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.2'
     implementation 'androidx.core:core-ktx:1.6.0'
     implementation 'androidx.appcompat:appcompat:1.3.1'
+    implementation("com.squareup.okhttp3:okhttp:4.9.0")
 
     testImplementation 'junit:junit:4.13.1'
     testImplementation 'androidx.test:core:1.4.0'

--- a/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
+++ b/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
@@ -73,6 +73,12 @@ interface RequestInterface {
     fun updateLocale(locale: Locale)
 
     /**
+     * This method can be called at all times after the WebView is presented, the Request interface will send the headers with every request.
+     * @param headers Set optional HTTP headers
+     */
+    fun update(headers: Map<String, String>?)
+
+    /**
      * Update the id token.
      *
      * @param requestId The request id of the event that informed that the token was expired.

--- a/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
+++ b/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
@@ -82,6 +82,8 @@ interface RequestInterface {
      * @param requestId The request id of the event that triggered the account provisioning.
      */
     fun accountProvisionInitiated(requestId: String)
+    fun accountRequestSucceeded(requestId: String)
+    fun accountRequestFailed(requestId: String, reason: String)
 
     /**
      * Instruct the web app to navigate to a [location].

--- a/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
+++ b/sdk/src/main/java/com/getdreams/connections/webview/RequestInterface.kt
@@ -30,11 +30,13 @@ interface RequestInterface {
      *
      * @param credentials Credentials used to authenticate the user.
      * @param locale The locale to use in Dreams.
+     * @param headers Set optional HTTP headers
      * @param onCompletion Called when [launch] has completed.
      */
     fun launch(
         credentials: Credentials,
         locale: Locale,
+        headers: Map<String, String>? = null,
         onCompletion: OnLaunchCompletion = OnLaunchCompletion {
             if (it is Result.Failure) {
                 Log.e("Dreams", "Failed to launch due to ${it.error.message}", it.error.cause)
@@ -47,12 +49,14 @@ interface RequestInterface {
      *
      * @param credentials Credentials used to authenticate the user.
      * @param locale The locale to use in Dreams.
+     * @param headers Set optional HTTP headers
      * @param location The location that Dreams should navigate to on a successful launch.
      * @param onCompletion Called when [launch] has completed.
      */
     fun launch(
         credentials: Credentials,
         locale: Locale,
+        headers: Map<String, String>? = null,
         location: String,
         onCompletion: OnLaunchCompletion = OnLaunchCompletion {
             if (it is Result.Failure) {

--- a/sdk/src/main/java/com/getdreams/connections/webview/ResponseInterface.kt
+++ b/sdk/src/main/java/com/getdreams/connections/webview/ResponseInterface.kt
@@ -28,6 +28,11 @@ internal interface ResponseInterface {
     fun onAccountProvisionRequested(requestData: String)
 
     /**
+     * An account should be requested.
+     */
+    fun onAccountRequested(requestData: String)
+
+    /**
      * The user requested to exit Dreams.
      */
     fun onExitRequested()

--- a/sdk/src/main/java/com/getdreams/events/Event.kt
+++ b/sdk/src/main/java/com/getdreams/events/Event.kt
@@ -36,4 +36,10 @@ sealed class Event {
      * Event sent when share should be triggered in Dreams.
      */
     object Share : Event()
+
+    /**
+     * Event informing that an account is requested.
+     */
+    data class AccountRequested(override val requestId: String, val dream: JSONObject) :  RequestData, Event()
+
 }

--- a/sdk/src/main/java/com/getdreams/views/DreamsView.kt
+++ b/sdk/src/main/java/com/getdreams/views/DreamsView.kt
@@ -164,6 +164,21 @@ class DreamsView : FrameLayout, DreamsViewInterface {
             }
 
             @JavascriptInterface
+            override fun onAccountRequested(requestData: String) {
+                try {
+                    val json = JSONTokener(requestData).nextValue() as? JSONObject?
+                    val dreamJson = json?.getJSONObject("dream") as JSONObject
+
+                    val requestId = json?.getString("requestId")
+                    if (requestId != null) {
+                        this@DreamsView.onResponse(Event.AccountRequested(requestId, dreamJson))
+                    }
+                } catch (e: JSONException) {
+                    Log.w("Dreams", "Unable to parse request data", e)
+                }
+            }
+
+            @JavascriptInterface
             override fun onExitRequested() {
                 this@DreamsView.onResponse(Event.ExitRequested)
             }
@@ -370,6 +385,25 @@ class DreamsView : FrameLayout, DreamsViewInterface {
         GlobalScope.launch(Dispatchers.Main.immediate) {
             webView.evaluateJavascript("accountProvisionInitiated('${jsonData}')") {
                 Log.v("Dreams", "accountProvisioned returned $it")
+            }
+        }
+    }
+
+    override fun accountRequestSucceeded(requestId: String) {
+        val jsonData: JSONObject = JSONObject()
+            .put("requestId", requestId)
+        GlobalScope.launch(Dispatchers.Main.immediate) {
+            webView.evaluateJavascript("accountRequestedSucceeded('${jsonData}')") {
+            }
+        }
+    }
+
+    override fun accountRequestFailed(requestId: String, reason: String) {
+        val jsonData: JSONObject = JSONObject()
+            .put("requestId", requestId)
+            .put("reason", reason)
+        GlobalScope.launch(Dispatchers.Main.immediate) {
+            webView.evaluateJavascript("accountRequestedFailed('${jsonData}')") {
             }
         }
     }


### PR DESCRIPTION
Set custom http headers during launch by using this functions on DreamsView (RequestInterface):


    /**
     * Launch Dreams.
     *
     * @param credentials Credentials used to authenticate the user.
     * @param locale The locale to use in Dreams.
     * @param headers Set optional HTTP headers
     * @param onCompletion Called when [launch] has completed.
     */
    fun launch(
        credentials: Credentials,
        locale: Locale,
        headers: Map<String, String>? = null,
        onCompletion: OnLaunchCompletion = OnLaunchCompletion {
            if (it is Result.Failure) {
                Log.e("Dreams", "Failed to launch due to ${it.error.message}", it.error.cause)
            }
        }
    )

    /**
     * Launch Dreams.
     *
     * @param credentials Credentials used to authenticate the user.
     * @param locale The locale to use in Dreams.
     * @param headers Set optional HTTP headers
     * @param location The location that Dreams should navigate to on a successful launch.
     * @param onCompletion Called when [launch] has completed.
     */
    fun launch(
        credentials: Credentials,
        locale: Locale,
        headers: Map<String, String>? = null,
        location: String,
        onCompletion: OnLaunchCompletion = OnLaunchCompletion {
            if (it is Result.Failure) {
                Log.e("Dreams", "Failed to launch due to ${it.error.message}", it.error.cause)
            }
        }
    )

And update them afterwards with function on DreamsView (RequestInterface):

    /**
     * This method can be called at all times after the WebView is presented, the Request interface will send the headers with every request.
     * @param headers Set optional HTTP headers
     */
    fun update(headers: Map<String, String>?)
    
Also signing process should be fixed and GPG should be used for signing (if it is properly setup in publishing workflow).
